### PR TITLE
[feat] 관리자 상품 추가 옵션리스트 구현

### DIFF
--- a/src/pages/admin/Product/ProductAddPage.jsx
+++ b/src/pages/admin/Product/ProductAddPage.jsx
@@ -112,23 +112,7 @@ function ProductAddPage () {
     const handlePriceChange = (prop) => (event) => {
         setPrice({ ...price, [prop]: event.target.value });
     };
-
-    /* 옵션 추가하기 */
-    const handleAddOption = () => {
-        if (optionInput && optionTags.length > 0) {
-            const newOptions = optionTags.map(tag => ({
-                optionName: optionInput,
-                optionValue: tag,
-                optionQuantity: parseInt(optionQuantities[tag], 10) || 0,
-            }));
-            setOptions([...options, ...newOptions]);
-            setOptionInput('');
-            setOptionTags([]);
-            setOptionQuantities({});
-        }
-    };
     
-
     /* 옵션값 스페이스바, 엔터로 분리 */
     const handleKeyUp = (event) => {
         if (event.key === ' ' || event.key === 'Enter') {
@@ -301,17 +285,6 @@ function ProductAddPage () {
                                     </TableRow>
                                 </TableHead>
                                 <TableBody>
-                                    {options.map((option) => (
-                                        <TableRow key={option.name}>
-                                            <TableCell>{option.name}</TableCell>
-                                            <TableCell>
-                                                <TextField
-                                                    type="number"
-                                                    size="small"
-                                                />
-                                            </TableCell>
-                                        </TableRow>
-                                    ))}
                                     {optionTags.map((tag, index) => (
                                         <TableRow key={index}>
                                             <TableCell>{tag.optionValue}</TableCell>
@@ -358,7 +331,6 @@ function ProductAddPage () {
                     sx={{ float: 'right'}}
                     variant="outlined"
                     onClick={() => {
-                        handleAddOption(); 
                         handleAddSubmit();
                     }}
                 >


### PR DESCRIPTION
- closed #126 
- 📣 **To Reviewers**
---
상품 추가에서 옵션 리스트를 도대체 어떻게 넣어야할지 감이 안잡혀서 옵션값을 태그로 생성할 때마다 배열을 만들기도 해보고, 상품 등록 직전에 넣은 값으로 배열을 만들기도 해봤는데 도저히 만들어지지를 않아서 헤매다가 결국 옵션명은 항상 같으니, 옵션값과 수량을 1차적으로 먼저 묶고 옵션리스트 배열을 만들었습니다. 각각 입력받은 값을 따로 넣어서 배열을 만들겠다는 무모한 생각을 했었던 것 같네요.. 아무튼 해결해서 다행입니다! 🥹

상품 추가는 api 호출 부분에서 오류가 있어서 다음 이슈에서 커밋하도록 하겠습니다. 또한 이미지는 오브젝트 스토리지와의 연동이 잘 안 돼서 추가 구현이 필요한 상황이고, 상품 등록 옵션 리스트에 대한 요청이 있었기 때문에 일단 먼저 상품 추가라도 올려두도록 하겠습니다..!